### PR TITLE
PixelPropsUtils: Add redfin fingerprint, code cleanup

### DIFF
--- a/core/java/com/android/internal/util/corvus/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/corvus/PixelPropsUtils.java
@@ -31,35 +31,36 @@ public class PixelPropsUtils {
 
     private static final Map<String, Object> propsToChange;
     private static final Map<String, Object> propsToChangePixelXL;
-    private static final Map<String, Object> propsToChangePixel3XL;
 
     private static final String[] packagesToChange = {
-	"com.android.vending",
-        "com.breel.wallpapers20",
-        "com.google.android.apps.customization.pixel",
-        "com.google.android.apps.fitness",
-        "com.google.android.apps.recorder",
-        "com.google.android.apps.subscriptions.red",
-        "com.google.android.apps.tachyon",
-        "com.google.android.apps.turboadapter",
-        "com.google.android.apps.wallpaper.pixel",
+        "com.google.android.ext.services",
+        "com.google.android.apps.pixelmigrate",
+        "com.google.android.apps.safetyhub",
         "com.google.android.as",
         "com.google.android.dialer",
-        "com.google.android.gms.location.history",
-        "com.google.android.inputmethod.latin",
-        "com.google.android.soundpicker",
-        "com.google.pixel.dynamicwallpapers",
-        "com.google.pixel.livewallpaper",
-        "com.google.android.apps.safetyhub",
+        "com.google.intelligence.sense",
+        "com.android.vending",
+        "com.google.android.apps.gcs",
         "com.google.android.apps.turbo",
-        "com.google.android.apps.wallpaper",
-        "com.google.android.apps.maps",
+        "com.google.android.apps.turboadapter",
+        "com.google.android.apps.wellbeing",
+        "com.google.android.configupdater",
         "com.google.android.gms",
-        "com.google.android.apps.nexuslauncher"
+        "com.google.android.googlequicksearchbox",
+        "com.google.android.settings.intelligence",
+        "com.google.android.setupwizard",
+        "com.google.android.apps.nexuslauncher",
+        "com.google.android.gsf",
+        "com.google.android.apps.wallpaper",
+        "com.google.android.onetimeinitializer",
+        "com.google.android.pixel.setupwizard",
+        "com.google.android.apps.messaging",
+        "com.google.android.apps.maps",
+        "com.google.android.apps.fitness"
     };
 
     private static final String[] packagesToChangePixelXL = {
-            "com.google.android.apps.photos"
+        "com.google.android.apps.photos"
     };
 
     private static final String[] packagesToChangePixel3XL = {
@@ -68,71 +69,71 @@ public class PixelPropsUtils {
 
     private static final Map<String, Object> propsToChangeROG1;
     private static final String[] packagesToChangeROG1 = {
-            "com.dts.freefireth",
-            "com.dts.freefiremax",
-            "com.madfingergames.legends"
+        "com.dts.freefireth",
+        "com.dts.freefiremax",
+        "com.madfingergames.legends"
     };
 
     private static final Map<String, Object> propsToChangeXP5;
     private static final String[] packagesToChangeXP5 = {
-            "com.activision.callofduty.shooter",
-            "com.tencent.tmgp.kr.codm",
-            "com.garena.game.codm",
-            "com.vng.codmvn"
+        "com.activision.callofduty.shooter",
+        "com.tencent.tmgp.kr.codm",
+        "com.garena.game.codm",
+        "com.vng.codmvn"
     };
 
     private static final Map<String, Object> propsToChangeOP8P;
     private static final String[] packagesToChangeOP8P = {
-            "com.tencent.ig",
-            "com.pubg.krmobile",
-            "com.pubg.newstate",
-            "com.vng.pubgmobile",
-            "com.rekoo.pubgm",
-            "com.tencent.tmgp.pubgmhd",
-            "com.riotgames.league.wildrift",
-            "com.riotgames.league.wildrifttw",
-            "com.riotgames.league.wildriftvn",
-            "com.netease.lztgglobal",
-            "com.epicgames.fortnite",
-            "com.epicgames.portal"
+        "com.tencent.ig",
+        "com.pubg.krmobile",
+        "com.pubg.newstate",
+        "com.vng.pubgmobile",
+        "com.rekoo.pubgm",
+        "com.tencent.tmgp.pubgmhd",
+        "com.riotgames.league.wildrift",
+        "com.riotgames.league.wildrifttw",
+        "com.riotgames.league.wildriftvn",
+        "com.netease.lztgglobal",
+        "com.epicgames.fortnite",
+        "com.epicgames.portal"
     };
 
     private static final Map<String, Object> propsToChangeK30U;
     private static final String[] packagesToChangeK30U = {
-            "com.pubg.imobile"
+        "com.pubg.imobile"
     };
 
     static {
         propsToChange = new HashMap<>();
         propsToChange.put("BRAND", "google");
         propsToChange.put("MANUFACTURER", "Google");
-        propsToChange.put("DEVICE", "walleye");
-        propsToChange.put("PRODUCT", "walleye");
-        propsToChange.put("MODEL", "Pixel 2");
-        propsToChange.put("FINGERPRINT", "google/walleye/walleye:8.1.0/OPM1.171019.011/4448085:user/release-keys");
-	propsToChangePixelXL = new HashMap<>();
+        propsToChange.put("DEVICE", "redfin");
+        propsToChange.put("PRODUCT", "redfin");
+        propsToChange.put("MODEL", "Pixel 5");
+        propsToChange.put("FINGERPRINT", "google/redfin/redfin:11/RQ3A.211001.001/7641976:user/release-keys");
+        propsToChangePixelXL = new HashMap<>();
         propsToChangePixelXL.put("BRAND", "google");
         propsToChangePixelXL.put("MANUFACTURER", "Google");
         propsToChangePixelXL.put("DEVICE", "marlin");
         propsToChangePixelXL.put("PRODUCT", "marlin");
         propsToChangePixelXL.put("MODEL", "Pixel XL");
         propsToChangePixelXL.put("FINGERPRINT", "google/marlin/marlin:10/QP1A.191005.007.A3/5972272:user/release-keys");
-	propsToChangePixel3XL = new HashMap<>();
+        propsToChangePixel3XL = new HashMap<>();
         propsToChangePixel3XL.put("BRAND", "google");
         propsToChangePixel3XL.put("MANUFACTURER", "Google");
         propsToChangePixel3XL.put("DEVICE", "crosshatch");
         propsToChangePixel3XL.put("PRODUCT", "crosshatch");
         propsToChangePixel3XL.put("MODEL", "Pixel 3 XL");
         propsToChangePixel3XL.put("FINGERPRINT", "google/crosshatch/crosshatch:11/RQ3A.210605.005/7349499:user/release-keys");
-    propsToChangeROG1 = new HashMap<>();
+        propsToChangeROG1 = new HashMap<>();
         propsToChangeROG1.put("MODEL", "ASUS_Z01QD");
         propsToChangeROG1.put("MANUFACTURER", "asus");
-    propsToChangeXP5 = new HashMap<>();
+        propsToChangeXP5 = new HashMap<>();
         propsToChangeXP5.put("MODEL", "SO-52A");
-    propsToChangeOP8P = new HashMap<>();
+        propsToChangeOP8P = new HashMap<>();
         propsToChangeOP8P.put("MODEL", "IN2020");
         propsToChangeOP8P.put("MANUFACTURER", "OnePlus");        
-    propsToChangeK30U = new HashMap<>();
+        propsToChangeK30U = new HashMap<>();
         propsToChangeK30U.put("MODEL", "M2006J10C");
         propsToChangeK30U.put("MANUFACTURER", "Xiaomi");
     }
@@ -148,11 +149,18 @@ public class PixelPropsUtils {
             for (Map.Entry<String, Object> prop : propsToChange.entrySet()) {
                 String key = prop.getKey();
                 Object value = prop.getValue();
+                if (packageName.equals("com.google.android.gms") && key.equals("MODEL")) {
+                    value = value + "\u200b";
+                }
                 setPropValue(key, value);
             }
         }
-	if (Arrays.asList(packagesToChangePixelXL).contains(packageName)){
-            if (DEBUG){
+        // Set proper indexing fingerprint
+        if (packageName.equals("com.google.android.settings.intelligence")) {
+            setPropValue("FINGERPRINT", Build.DATE);
+        }
+        if (Arrays.asList(packagesToChangePixelXL).contains(packageName)) {
+            if (DEBUG) {
                 Log.d(TAG, "Defining props for: " + packageName);
             }
             for (Map.Entry<String, Object> prop : propsToChangePixelXL.entrySet()) {
@@ -161,7 +169,7 @@ public class PixelPropsUtils {
                 setPropValue(key, value);
             }
         }
-	if (Arrays.asList(packagesToChangePixel3XL).contains(packageName)) {
+	    if (Arrays.asList(packagesToChangePixel3XL).contains(packageName)) {
             if (DEBUG) {
                 Log.d(TAG, "Defining props for: " + packageName);
             }
@@ -172,41 +180,40 @@ public class PixelPropsUtils {
             }
         }
         // Set proper indexing fingerprint
-    if (packageName.equals("com.google.android.settings.intelligence")) {
+        if (packageName.equals("com.google.android.settings.intelligence")) {
             setPropValue("FINGERPRINT", Build.DATE);
-        }
-            } else {
-                if (Arrays.asList(packagesToChangeROG1).contains(packageName)) {
-                    if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
-                    for (Map.Entry<String, Object> prop : propsToChangeROG1.entrySet()) {
-                        String key = prop.getKey();
-                        Object value = prop.getValue();
-                        setPropValue(key, value);
-                    }
+        } else {
+            if (Arrays.asList(packagesToChangeROG1).contains(packageName)) {
+                if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
+                for (Map.Entry<String, Object> prop : propsToChangeROG1.entrySet()) {
+                    String key = prop.getKey();
+                    Object value = prop.getValue();
+                    setPropValue(key, value);
+                }
             } else if (Arrays.asList(packagesToChangeXP5).contains(packageName)) {
                 if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
-                    for (Map.Entry<String, Object> prop : propsToChangeXP5.entrySet()) {
-                        String key = prop.getKey();
-                        Object value = prop.getValue();
-                        setPropValue(key, value);
+                for (Map.Entry<String, Object> prop : propsToChangeXP5.entrySet()) {
+                    String key = prop.getKey();
+                    Object value = prop.getValue();
+                    setPropValue(key, value);
                 }
             } else if (Arrays.asList(packagesToChangeOP8P).contains(packageName)) {
                 if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
-                    for (Map.Entry<String, Object> prop : propsToChangeOP8P.entrySet()) {
-                        String key = prop.getKey();
-                        Object value = prop.getValue();
-                        setPropValue(key, value);
-                    }
+                for (Map.Entry<String, Object> prop : propsToChangeOP8P.entrySet()) {
+                    String key = prop.getKey();
+                    Object value = prop.getValue();
+                    setPropValue(key, value);
+                }
             } else if (Arrays.asList(packagesToChangeK30U).contains(packageName)) {
                 if (DEBUG) Log.d(TAG, "Defining props for: " + packageName);
-                    for (Map.Entry<String, Object> prop : propsToChangeK30U.entrySet()) {
-                        String key = prop.getKey();
-                        Object value = prop.getValue();
-                        setPropValue(key, value);
-                    }                    
+                for (Map.Entry<String, Object> prop : propsToChangeK30U.entrySet()) {
+                    String key = prop.getKey();
+                    Object value = prop.getValue();
+                    setPropValue(key, value);
+                }
             }        
         }
-
+    }
     private static void setPropValue(String key, Object value) {
         try {
             if (DEBUG) {
@@ -220,5 +227,4 @@ public class PixelPropsUtils {
             Log.e(TAG, "Failed to set prop " + key, e);
         }
     }
-
 }

--- a/core/java/com/android/internal/util/corvus/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/corvus/PixelPropsUtils.java
@@ -31,6 +31,7 @@ public class PixelPropsUtils {
 
     private static final Map<String, Object> propsToChange;
     private static final Map<String, Object> propsToChangePixelXL;
+    private static final Map<String, Object> propsToChangePixel3XL;
 
     private static final String[] packagesToChange = {
         "com.google.android.ext.services",


### PR DESCRIPTION
- Took some PixelPropsUtils code from PixelOS eleven branch.
- Added redfin fingerprint to make features such as nearby share to work on devices.
- Code cleanup because code was messy, inconsistent, and had bad syntax (compile errors).