### PR TITLE
SystemUI: Fix a syntax error in `Android.bp`

### DIFF
--- a/packages/SystemUI/Android.bp
+++ b/packages/SystemUI/Android.bp
@@ -73,10 +73,10 @@ android_library {
         "airbnb-lottie",
         "faceunlock_framework",
         "jsr330",
-        "vendor.lineage.biometrics.fingerprint.inscreen-V1.0-java"
+        "vendor.lineage.biometrics.fingerprint.inscreen-V1.0-java",
         "monetcompat",
-        
     ],
+
     manifest: "AndroidManifest.xml",
 
     libs: [


### PR DESCRIPTION
*error: frameworks/base/packages/SystemUI/Android.bp:77:9: expected "]", found String
22:40:36 soong minibootstrap failed with: exit status 1